### PR TITLE
Make build work on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: hxdmp
 
 hxdmp: main.c Makefile
-	clang main.c -o hxdmp -O3 -lstdc++
+	${CC} main.c -o hxdmp -O3 -lstdc++
 
 install: hxdmp
 	cp hxdmp /usr/local/bin/hxdmp

--- a/main.c
+++ b/main.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <getopt.h>


### PR DESCRIPTION
Small changes that were required here to make `make` pass on Ubuntu 18.04.
